### PR TITLE
fix: alpine based dns issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM ubuntu:20.10
 
 ARG BUILD_DATE
 ARG VERSION
@@ -8,28 +8,19 @@ ARG TARGETOS
 
 LABEL maintainer="jenkins-x"
 
-RUN addgroup -S app \
-    && adduser -S -g app app \
-    && apk --no-cache add \
-    ca-certificates curl git netcat-openbsd
-
 # kubectl
 ENV KUBECTL_VERSION 1.16.15
 
 # see https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
 RUN echo using kubectl version ${KUBECTL_VERSION} and OS ${TARGETOS} arch ${TARGETARCH} && \
+  apt-get update && apt-get -y install curl ca-certificates git netcat-openbsd && \
   curl -LO  https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/${TARGETOS}/${TARGETARCH}/kubectl && \
   mv kubectl /usr/bin/kubectl && \
   chmod +x /usr/bin/kubectl
 
 RUN echo using jx-git-operator version ${VERSION} and OS ${TARGETOS} arch ${TARGETARCH} && \
   mkdir -p /home/.jx3 && \
-  curl -L https://github.com/jenkins-x/jx-git-operator/releases/download/v${VERSION}/jx-git-operator-${TARGETOS}-${TARGETARCH}.tar.gz | tar xzv && \
+  curl -L https://github.com/jenkins-x/jx-git-operator/releases/download/v${VERSION}/jx-git-operator-${TARGETOS}-${TARGETARCH}.tar.gz | tar -zxv && \
   mv jx-git-operator /usr/bin
 
-WORKDIR /home/app
-
-USER app
-
 ENTRYPOINT ["jx-git-operator"]
-


### PR DESCRIPTION
Issue: Alpine based Git operator pod unable to reach the internet when running on Minikube. The alpine issue is well defined [https://stackoverflow.com/questions/65181012/does-alpine-have-known-dns-issue-within-kubernetes](url) and i went for last option from the link above. 

Fix: use ubuntu base image for git operator pod

