### PR TITLE
Updated the Go version inside go.mod and edited dependencies.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jenkins-x/jx-git-operator
 
-go 1.18
+go 1.19
 
 require (
 	github.com/google/uuid v1.2.0

--- a/pkg/launcher/job/job_launcher.go
+++ b/pkg/launcher/job/job_launcher.go
@@ -3,7 +3,6 @@ package job
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -154,7 +153,7 @@ func (c *client) startNewJob(ctx context.Context, opts launcher.LaunchOptions, j
 			return nil, errors.Wrapf(err, "failed to check for file %s", fileNamePath)
 		}
 		if exists {
-			data, err := ioutil.ReadFile(fileNamePath)
+			data, err := os.ReadFile(fileNamePath)
 			if err != nil {
 				return nil, errors.Wrapf(err, "failed to load file %s", fileNamePath)
 			}

--- a/pkg/launcher/job/job_launcher_test.go
+++ b/pkg/launcher/job/job_launcher_test.go
@@ -1,11 +1,12 @@
 package job_test
 
 import (
-	"github.com/jenkins-x/jx-helpers/v3/pkg/yamls"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/jenkins-x/jx-helpers/v3/pkg/yamls"
 
 	"github.com/jenkins-x/jx-git-operator/pkg/constants"
 	"github.com/jenkins-x/jx-git-operator/pkg/launcher"
@@ -33,7 +34,7 @@ func TestJobLauncher(t *testing.T) {
 	repoURL := "https://github.com/jenkins-x/fake-repository.git"
 	lastCommitURL := strings.TrimSuffix(repoURL, ".git") + "/commit/" + gitSha
 
-	fs, err := ioutil.ReadDir("test_data")
+	fs, err := os.ReadDir("test_data")
 	require.NoError(t, err, "failed to load test data")
 
 	for _, f := range fs {

--- a/pkg/poller/poller.go
+++ b/pkg/poller/poller.go
@@ -1,7 +1,7 @@
 package poller
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -208,7 +208,7 @@ func (o *Options) ValidateOptions() error {
 		}
 	}
 	if o.Dir == "" {
-		o.Dir, err = ioutil.TempDir("", "jx-git-operator-")
+		o.Dir, err = os.MkdirTemp("", "jx-git-operator-")
 		if err != nil {
 			return errors.Wrapf(err, "failed to create temp dir")
 		}

--- a/pkg/poller/poller_test.go
+++ b/pkg/poller/poller_test.go
@@ -2,7 +2,6 @@ package poller_test
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -35,7 +34,7 @@ func TestPoller(t *testing.T) {
 	resourcesDir, err := filepath.Abs(filepath.Join("test_data", "somerepo", ".jx", "git-operator", "resources"))
 	require.NoError(t, err, "failed to get absolute dir %s", resourcesDir)
 
-	tmpDir, err := ioutil.TempDir("", "test-jx-git-operator-")
+	tmpDir, err := os.MkdirTemp("", "test-jx-git-operator-")
 	require.NoError(t, err, "failed to create temp dir")
 
 	t.Logf("running in dir %s", tmpDir)


### PR DESCRIPTION
I went through the last PR related to upgrading Go version 1.19 and noticed there's a few linting errors. 
I went through the documentations and removed the references which were deprecated. 

The linting errors should be fixed now. 
