### PR TITLE
chore: Update kubectl version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG TARGETOS
 LABEL maintainer="jenkins-x"
 
 # kubectl
-ENV KUBECTL_VERSION 1.16.15
+ENV KUBECTL_VERSION 1.23.16
 
 # see https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
 RUN echo using kubectl version ${KUBECTL_VERSION} and OS ${TARGETOS} arch ${TARGETARCH} && \


### PR DESCRIPTION
We seem to be using a very old version of kubectl in the container image here. Considering 1.22 is the oldest supported k8s version and kubectl's version skew policy, updating to 1.23.x made sense.