### PR TITLE
chore: update syft to support --enrich flags that goreleaser passes

### DIFF
--- a/.github/workflows/jenkins-x/upload-binaries.sh
+++ b/.github/workflows/jenkins-x/upload-binaries.sh
@@ -27,7 +27,7 @@ export ROOTPACKAGE="github.com/$REPOSITORY"
 
 # Install syft
 curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | \
-sh -s -- -b /usr/local/bin v0.54.0
+sh -s -- -b /usr/local/bin v1.18.1
 chmod +x /usr/local/bin/syft
 
 


### PR DESCRIPTION
- update syft to latest version to support goreleaser flags